### PR TITLE
scaling policy

### DIFF
--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -20,6 +20,12 @@ CfhighlanderTemplate do
       ComponentParam 'DnsDomain'
     end
 
+    ComponentParam 'DesiredCount', 1
+    ComponentParam 'MinimumHealthyPercent', 100
+    ComponentParam 'MaximumPercent', 200
+
+    ComponentParam 'EnableScaling', 'false', allowedValues: ['true','false']
+
     if ((defined? network_mode) && (network_mode == "awsvpc"))
       maximum_availability_zones.times do |az|
         ComponentParam "SubnetCompute#{az}"

--- a/ecs-service.config.yaml
+++ b/ecs-service.config.yaml
@@ -5,6 +5,8 @@ log_retention: 7
 
 # network_mode: awsvpc
 
+# health_check_grace_period: 60
+#
 # cpu: 256
 # memory: 256
 #
@@ -48,3 +50,17 @@ log_retention: 7
 #       priority: 20
 #   tags:
 #       Name: api
+
+# scaling_policy:
+#   min: 2
+#   max: 4
+#   up:
+#     cooldown: 150
+#     threshold: 70
+#     evaluation_periods: 5
+#     adjustment: 2
+#   down:
+#     cooldown: 600
+#     threshold: 70
+#     evaluation_periods: 5
+#     adjustment: -1


### PR DESCRIPTION
Sets simple step adjustment for scaling tasks using a configurable alarm for both scale up and down

```yaml
scaling_policy:
  min: 2
  max: 4
  up:
    cooldown: 150
    threshold: 70
    evaluation_periods: 5
    adjustment: 2
  down:
    cooldown: 600
    threshold: 70
    evaluation_periods: 5
    adjustment: -1
```
Default alarm is CPUUtilization for the ECS cluster
```ruby
    default_alarm = {}
    default_alarm['metric_name'] = 'CPUUtilization'
    default_alarm['namespace'] = 'AWS/ECS'
    default_alarm['statistic'] = 'Average'
    default_alarm['period'] = '60'
    default_alarm['evaluation_periods'] = '5'
    default_alarm['dimentions'] = [
      { Name: 'ServiceName', Value: FnGetAtt(:Service,:Name)},
      { Name: 'ClusterName', Value: Ref('EcsCluster')}
    ]
```