### PR TITLE
removed to_i conversion of ListerRule Priority

### DIFF
--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -255,7 +255,7 @@ CloudFormation do
           Actions [{ Type: "forward", TargetGroupArn: Ref('TaskTargetGroup') }]
           Conditions listener_conditions
           ListenerArn Ref("Listener")
-          Priority rule['priority'].to_i
+          Priority rule['priority']
         end
 
       end


### PR DESCRIPTION
ElasticLoadBalancingV2_ListenerRule Priority will no longer be converted to an integer value.
This allows the value of the priority to be set using a Ref.
This will require that any priorities set in the the config yaml or passed by Ref will need to be an integer