### PR TITLE
Added optional name key for ListenerRules

### DIFF
--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -251,7 +251,15 @@ CloudFormation do
           listener_conditions << { Field: "host-header", Values: hosts }
         end
 
-        ElasticLoadBalancingV2_ListenerRule("TargetRule#{rule['priority']}") do
+        if rule.key?("name")
+          rule_name = rule['name']
+        elsif rule['priority'].is_a? Integer
+          rule_name = "TargetRule#{rule['priority']}"
+        else
+          rule_name = "TargetRule#{index}"
+        end
+
+        ElasticLoadBalancingV2_ListenerRule(rule_name) do
           Actions [{ Type: "forward", TargetGroupArn: Ref('TaskTargetGroup') }]
           Conditions listener_conditions
           ListenerArn Ref("Listener")

--- a/ecs-service.config.yaml
+++ b/ecs-service.config.yaml
@@ -50,7 +50,8 @@ log_retention: 7
 #     path: /status
 #     code: 200
 #   rules:
-#     - path: /v2/*
+#     - name:  apiv2
+#       path: /v2/*
 #       host: api.*
 #       priority: 10
 #     - path: /api/v1/*


### PR DESCRIPTION
Adds the ability to explicitly set the logicalID of an AWS::ElasticLoadBalancingV2::ListenerRule
If the rule priority is set in config as an integer the original naming convention will be used.
If the rule priority is set by another method then the index will be used in the logicalID

