### PR TITLE
Fix fargate condition error

### DIFF
--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -3,10 +3,11 @@ CloudFormation do
   awsvpc_enabled = false
   if defined?(network_mode) && network_mode == 'awsvpc'
     awsvpc_enabled = true
+    Condition('IsFargate', FnEquals(Ref('EnableFargate'), 'true'))
   end
 
   Condition('IsScalingEnabled', FnEquals(Ref('EnableScaling'), 'true'))
-  Condition('IsFargate', FnEquals(Ref('EnableFargate'), 'true'))
+  
 
   log_retention = 7 unless defined?(log_retention)
   Resource('LogGroup') {


### PR DESCRIPTION
Ref to FargateEnabled param was used in condition.
Broke validation when network type was not awsvpc and the param was not defined.
The IsFargate condition now only created when the FargateEnabled param is created