### PR TITLE
Fix having multiple links

### DIFF
--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -69,9 +69,11 @@ CloudFormation do
 
     # add links
     if task.key?('links')
-      task['links'].each do |links|
-      task_def.merge!({ Links: [ links ] })
+      links = []
+      task['links'].each do |link|
+        links.append(link)
       end
+      task_def.merge!({ Links: links })
     end
 
     # add entrypoint

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -20,7 +20,7 @@ CloudFormation do
 
   task_definition.each do |task_name, task|
 
-    env_vars, mount_points, ports = Array.new(3){[]}
+    env_vars, mount_points, ports, volumes_from, port_mappings = Array.new(5){[]}
 
     name = task.has_key?('name') ? task['name'] : task_name
 
@@ -69,17 +69,15 @@ CloudFormation do
 
     # add links
     if task.key?('links')
-      links = []
-      task['links'].each do |link|
-        links.push(link)
+      if task['links'].kind_of?(Array)
+        task_def.merge!({ Links: task['links'] })
       end
-      task_def.merge!({ Links: links })
     end
 
     # add entrypoint
     if task.key?('entrypoint')
-      task['entrypoint'].each do |entrypoint|
-      task_def.merge!({ EntryPoint: entrypoint })
+      if task['entrypoint'].kind_of?(Array)
+        task_def.merge!({ EntryPoint: task['entrypoint'] })
       end
     end
 
@@ -99,24 +97,26 @@ CloudFormation do
       task_def.merge!({MountPoints: mount_points })
     end
 
-    # volumes from
+    # add volumes from
     if task.key?('volumes_from')
-      task['volumes_from'].each do |source_container|
-      task_def.merge!({ VolumesFrom: [ SourceContainer: source_container ] })
+      if task['volumes_from'].kind_of?(Array)
+        task['volumes_from'].each do |source_container|
+          volumes_from << { SourceContainer: source_container }
+        end
+        task_def.merge!({ VolumesFrom: volumes_from })
       end
     end
 
     # add port
     if task.key?('ports')
-      port_mapppings = []
       task['ports'].each do |port|
         port_array = port.to_s.split(":").map(&:to_i)
         mapping = {}
         mapping.merge!(ContainerPort: port_array[0])
         mapping.merge!(HostPort: port_array[1]) if port_array.length == 2
-        port_mapppings << mapping
+        port_mappings << mapping
       end
-      task_def.merge!({PortMappings: port_mapppings})
+      task_def.merge!({PortMappings: port_mappings})
     end
 
     task_def.merge!({EntryPoint: task['entrypoint'] }) if task.key?('entrypoint')

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -71,7 +71,7 @@ CloudFormation do
     if task.key?('links')
       links = []
       task['links'].each do |link|
-        links.append(link)
+        links.insert(link)
       end
       task_def.merge!({ Links: links })
     end

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -71,7 +71,7 @@ CloudFormation do
     if task.key?('links')
       links = []
       task['links'].each do |link|
-        links.insert(link)
+        links.push(link)
       end
       task_def.merge!({ Links: links })
     end

--- a/tests/multiple-links.test.yaml
+++ b/tests/multiple-links.test.yaml
@@ -1,0 +1,39 @@
+test_metadata:
+  type: config
+  name: nginx
+  description: create a nginx ecs service with a targetgroup
+
+task_definition: 
+
+  nginx:
+    repo: nginx
+    image: nginx
+
+  db:
+    image: postgres
+    ports:
+      - 5432
+
+  redis:
+    image: redis
+    ports:
+      - 6379
+
+  php-fpm:
+    image: php-fpm
+    ports:
+      - 9000
+    links:
+      - db:db
+      - redis:redis
+      - nginx:nginx
+
+targetgroup:
+  name: nginx
+  container: nginx
+  port: 80
+  protocol: http
+  listener: http
+  healthcheck:
+    path: /
+    code: 200

--- a/tests/multiple-links.test.yaml
+++ b/tests/multiple-links.test.yaml
@@ -23,10 +23,14 @@ task_definition:
     image: php-fpm
     ports:
       - 9000
+      - 9001
     links:
       - db:db
       - redis:redis
       - nginx:nginx
+    volumes_from:
+      - db
+      - redis
 
 targetgroup:
   name: nginx


### PR DESCRIPTION
Previously when adding multiple links, it would overwrite the previous iteration and only keep the last link specified. Eg:

    links:
      - db:db
      - redis:redis
      - elasticache:elasticache

Would only set elasticache as a link in the task defintion. This change fixes this, appending each new entry into an array before merging into the task definiton


