### PR TITLE
Allow empty launchtype (uses default capacity provider)

### DIFF
--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -36,6 +36,7 @@ CfhighlanderTemplate do
       ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
       ComponentParam 'SecurityGroupBackplane'
       ComponentParam 'EnableFargate', 'false'
+      ComponentParam 'DisableLaunchType', 'false'
     end
 
     task_definition.each do |task_def, task|

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -7,6 +7,7 @@ CloudFormation do
   if network_mode == 'awsvpc'
     awsvpc_enabled = true
     Condition('IsFargate', FnEquals(Ref('EnableFargate'), 'true'))
+    Condition('IsEmptyLaunchType', FnEquals(Ref('DisableLaunchType'), 'true'))
   end
 
   tags = []
@@ -433,7 +434,7 @@ CloudFormation do
   ECS_Service('Service') do
     DependsOn rule_names if rule_names.any?
     if awsvpc_enabled
-        LaunchType FnIf('IsFargate', 'FARGATE', 'EC2')
+        LaunchType FnIf('IsEmptyLaunchType', Ref('AWS::NoValue'), FnIf('IsFargate', 'FARGATE', 'EC2'))
     end
     Cluster Ref("EcsCluster")
     HealthCheckGracePeriodSeconds health_check_grace_period if !health_check_grace_period.nil?


### PR DESCRIPTION
Hi, 

I'd like each of my tasks to use the default capacity provider strategy (instead of overriding it per task). 

It's because:
  1) CapacityProvider in Cloudformation for a service/task is not yet supported (yes, I know)
  2) I want services/tasks to just use the bloody cluster default. 

I tested both with IsFargate  and default. 

To verify it worked, you need to create the capacity provider strategy manually (not supported in Cloudformation yet, of course):

`aws ecs put-cluster-capacity-providers \
     --cluster dev-ecs-1NUU9R8NGTKPO-EcsCluster-13DSZZHYQ83NM \
     --capacity-providers FARGATE FARGATE_SPOT \
     --default-capacity-provider-strategy capacityProvider=FARGATE_SPOT,weight=1 \
     --region ap-southeast-2 --profile dev`


And then, if you use `DisableLaunchType` to not set the LaunchType, and deploy that task, you can see (using the API only!) that it's now using the FARGATE_SPOT:

`
aws ecs list-services --cluster <cluster> --query 'serviceArns[*]' --output text  | xargs -n1 -I F aws ecs describe-services --cluster <cluster> --services F --query 'services[*].[serviceName,launchType,capacityProviderStrategy[0].capacityProvider]' --output text
`
