### PR TITLE
Add parameter to prevent exports/outputs being generated

### DIFF
--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -31,13 +31,13 @@ CfhighlanderTemplate do
     ComponentParam 'MaximumPercent', 200
 
     ComponentParam 'EnableScaling', 'false', allowedValues: ['true','false']
+    ComponentParam 'EnableExports', 'true', allowedValues: ['true','false']
 
     if ((defined? network_mode) && (network_mode == "awsvpc"))
       ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
       ComponentParam 'SecurityGroupBackplane'
       ComponentParam 'EnableFargate', 'false'
       ComponentParam 'DisableLaunchType', 'false'
-      ComponentParam 'EnableExports', 'true', allowedValues: ['true','false']
     end
 
     task_definition.each do |task_def, task|

--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -37,6 +37,7 @@ CfhighlanderTemplate do
       ComponentParam 'SecurityGroupBackplane'
       ComponentParam 'EnableFargate', 'false'
       ComponentParam 'DisableLaunchType', 'false'
+      ComponentParam 'EnableExports', 'true', allowedValues: ['true','false']
     end
 
     task_definition.each do |task_def, task|

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -16,6 +16,8 @@ CloudFormation do
   tags << { Key: "EnvironmentType", Value: Ref("EnvironmentType") }
 
   Condition('IsScalingEnabled', FnEquals(Ref('EnableScaling'), 'true'))
+  Condition('IsExportsEnabled', FnEquals(Ref('EnableExports'), 'true'))
+
 
   log_retention = external_parameters.fetch(:log_retention, 7)
 
@@ -423,10 +425,11 @@ CloudFormation do
       }
       sg_name = 'ServiceSecurityGroup'
     end
-    
+
     Output(:SecurityGroup) {
       Value(Ref(sg_name))
       Export FnSub("${EnvironmentName}-#{export}-SecurityGroup")
+      Condition 'IsExportsEnabled'
     }
   end
 
@@ -628,6 +631,7 @@ CloudFormation do
   Output("ServiceName") do
     Value(FnGetAtt(:Service, :Name))
     Export FnSub("${EnvironmentName}-#{export}-ServiceName")
+    Condition 'IsExportsEnabled'
   end unless task_definition.empty?
 
 end


### PR DESCRIPTION
So here's my problem. 

I have a project that deploy feature branches as new stacks. 
I do have all feature branches as the same EnvironmentName, and I don't have different configuration per feature branch. 

So changing parameters for me is trivial for feature branches vs master. But it's not easy to deploy a different config file per branch, as I'd need to generate it during build time. 

Is this an acceptable change? I believe it shouldn't break anything. 

You should be able to edit the PR with anything you need. 