### PR TITLE
Specify a single service and targetgroup with multiple ports

### DIFF
--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -392,11 +392,16 @@ CloudFormation do
       targetgroup_arn = Ref('TargetGroup')
     end
 
-    service_loadbalancer << {
-      ContainerName: targetgroup['container'],
-      ContainerPort: targetgroup['port'],
-      TargetGroupArn: targetgroup_arn
-    }
+    container_ports = external_parameters.fetch(:container_ports, [targetgroup['port']])
+
+    container_ports.each do |container_port|
+      service_loadbalancer << {
+        ContainerName: targetgroup['container'],
+        ContainerPort: container_port,
+        TargetGroupArn: targetgroup_arn
+      }
+    end
+    
   end
 
   unless awsvpc_enabled

--- a/tests/multiple_targetgroup_ports.test.yaml
+++ b/tests/multiple_targetgroup_ports.test.yaml
@@ -1,0 +1,30 @@
+test_metadata:
+  type: config
+  name: multiple_targetgroup_ports
+  description: |
+    Add the same ecs service to the same target group multiple times with different ports.
+    If container_ports key is specified with list of ports those ports are used to add multiple target group references to the ECS service.
+    If container_ports is not set the default target group port is used.
+
+task_definition:
+  nginx:
+    repo: nginx
+    image: nginx
+    ports:
+      - 8080
+      - 8081
+      - 8082
+
+targetgroup:
+  name: nginx
+  container: nginx
+  port: 8080
+  container_ports:
+    - 8080
+    - 8081
+    - 8082
+  protocol: http
+  listener: http
+  healthcheck:
+    path: /
+    code: 200


### PR DESCRIPTION
### Changes

Add the same ecs service to the same target group multiple times with different ports.
- If container_ports key is specified with list of ports those ports are used to add multiple target group references to the ECS service.
- If container_ports is not set the default target group port is used.

### Example Config

```yaml
task_definition:
  nginx:
    repo: nginx
    image: nginx
    ports:
      - 8080
      - 8081
      - 8082

targetgroup:
  name: nginx
  container: nginx
  port: 8080
  container_ports:
    - 8080
    - 8081
    - 8082
  protocol: http
  listener: http
  healthcheck:
    path: /
    code: 200
```