### PR TITLE
add the same ecs serice to multiple target groups

### DIFF
--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -22,10 +22,21 @@ CfhighlanderTemplate do
     end
 
     if defined? targetgroup
-      ComponentParam 'LoadBalancer'
-      ComponentParam 'TargetGroup'
-      ComponentParam 'Listener'
       ComponentParam 'DnsDomain'
+
+      if targetgroup.is_a?(Array)
+        targetgroup.each do |tg|
+          if tg.has_key?('rules')
+            ComponentParam "#{tg['listener']}Listener"
+          else
+            ComponentParam "#{tg['name'].gsub(/[^0-9A-Za-z]/, '')}TargetGroup"
+          end
+        end
+      else
+        ComponentParam 'TargetGroup'
+        ComponentParam 'Listener'
+        ComponentParam 'LoadBalancer'
+      end
     end
 
     ComponentParam 'DesiredCount', 1

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -368,7 +368,6 @@ CloudFormation do
         end
         
         targetgroup['rules'].each_with_index do |rule, index|
-          puts rule
           listener_conditions = []
           if rule.key?("path")
             listener_conditions << { Field: "path-pattern", Values: [ rule["path"] ] }

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -319,7 +319,7 @@ CloudFormation do
 
     if !targetgroups.is_a?(Array)
       # Keep original resource names for backwards compatibility
-      targetgroups['resource_name'] = targetgroup.has_key?('rules') ? 'TargetGroup' : 'TaskTargetGroup'
+      targetgroups['resource_name'] = targetgroup.has_key?('rules') ? 'TaskTargetGroup' : 'TargetGroup'
       targetgroups['listener_resource'] = 'Listener'
       targetgroups = [targetgroups]
     else

--- a/tests/multiple_target_groups.test.yaml
+++ b/tests/multiple_target_groups.test.yaml
@@ -1,0 +1,34 @@
+test_metadata:
+  type: config
+  name: multiple_target_groups
+  description: |
+    Place a ECS Service in multiple target groups to either set behind multiple loadbalancers or listerens in the same loadbalancer
+
+task_definition:
+  nginx:
+    repo: nginx
+    image: nginx
+    ports:
+      - 80
+      - 443
+        
+
+targetgroup:
+-
+  name: nginx-http
+  container: nginx
+  port: 80
+  protocol: http
+  listener: http
+  healthcheck:
+    path: /
+    code: 200
+-
+  name: nginx-https
+  container: nginx
+  port: 443
+  protocol: https
+  listener: https
+  healthcheck:
+    path: /
+    code: 200

--- a/tests/multiple_target_groups.test.yaml
+++ b/tests/multiple_target_groups.test.yaml
@@ -3,6 +3,7 @@ test_metadata:
   name: multiple_target_groups
   description: |
     Place a ECS Service in multiple target groups to either set behind multiple loadbalancers or listerens in the same loadbalancer
+    A target group resource is created for each object in the targetgroup array and generates resource names based upon the config values nor name and listener
 
 task_definition:
   nginx:
@@ -23,6 +24,10 @@ targetgroup:
   healthcheck:
     path: /
     code: 200
+  rules:
+    - name: webhttp
+      priority: 100
+      host: www.*
 -
   name: nginx-https
   container: nginx
@@ -32,3 +37,7 @@ targetgroup:
   healthcheck:
     path: /
     code: 200
+  rules:
+    - name: webhttps
+      priority: 100
+      host: www.*

--- a/tests/multiple_target_groups_parameter.test.yaml
+++ b/tests/multiple_target_groups_parameter.test.yaml
@@ -1,0 +1,25 @@
+test_metadata:
+  type: config
+  name: multiple_target_groups
+  description: |
+    Place a ECS Service in multiple target groups to either set behind multiple loadbalancers or listerens in the same loadbalancer
+    A parameter is created for each target group reference in the target group array
+
+task_definition:
+  nginx:
+    repo: nginx
+    image: nginx
+    ports:
+      - 80
+      - 443
+        
+
+targetgroup:
+-
+  name: nginx-http
+  container: nginx
+  port: 80
+-
+  name: nginx-https
+  container: nginx
+  port: 443


### PR DESCRIPTION
Super-seeds #58 

## Changes

Adds the ability to add a ECS service to multiple target groups
backwards compatible resource names and config

## Example Config

see test cases in PR