### PR TITLE
Feature/cognito support

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -3,23 +3,6 @@ name: cftest
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: test
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: set up ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
-    - name: install gems
-      run: gem install cfhighlander rspec 
-    - name: set cfndsl spec
-      run: cfndsl -u
-    - name: cftest
-      run: rspec
-      env:
-        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: ap-southeast-2
+  rspec:
+    uses: theonestack/shared-workflows/.github/workflows/rspec.yaml@main
+    secrets: inherit

--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -9,7 +9,7 @@ CfhighlanderTemplate do
   end
 
   DependsOn 'lib-iam'
-  DependsOn 'lib-alb@feature/cognito_listener_rules'
+  DependsOn 'lib-alb'
 
   Description "ecs-service - #{component_name} - #{component_version}"
 

--- a/ecs-service.cfhighlander.rb
+++ b/ecs-service.cfhighlander.rb
@@ -9,6 +9,7 @@ CfhighlanderTemplate do
   end
 
   DependsOn 'lib-iam'
+  DependsOn 'lib-alb@feature/cognito_listener_rules'
 
   Description "ecs-service - #{component_name} - #{component_version}"
 
@@ -16,6 +17,9 @@ CfhighlanderTemplate do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', allowedValues: ['development','production'], isGlobal: true
     ComponentParam 'EcsCluster'
+    ComponentParam 'UserPoolId', ''
+    ComponentParam 'UserPoolClientId', ''
+    ComponentParam 'UserPoolDomainName', ''
 
     if (defined? targetgroup) || ((defined? network_mode) && (network_mode == "awsvpc"))
       ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -412,8 +412,8 @@ CloudFormation do
           end
   
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
-            Actions [{ Type: "forward", TargetGroupArn: Ref(targetgroup['resource_name']) }]
-            Conditions actions
+            Actions actions
+            Conditions listener_conditions
             ListenerArn Ref(targetgroup['listener_resource'])
             Priority rule['priority']
           end

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -17,6 +17,7 @@ CloudFormation do
 
   Condition('IsScalingEnabled', FnEquals(Ref('EnableScaling'), 'true'))
   Condition('NoDesiredCount', FnEquals(Ref('DesiredCount'), '-1'))
+  Condition(:EnableCognito, FnNot(FnEquals(Ref(:UserPoolClientId), '')))
 
   log_retention = external_parameters.fetch(:log_retention, 7)
   loggroup_name = external_parameters.fetch(:loggroup_name, Ref('AWS::StackName'))
@@ -402,17 +403,11 @@ CloudFormation do
           end
           rule_names << rule_name
 
-          actions = []
-          actions << { Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name']) }
-
-          if targetgroup.has_key?('cognito')
-            if targetgroup['cognito'] == true
-              actions << cognito(self)
-            end
-          end
+          actions = [{ Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name'])}]
+          actions_with_cognito = actions + [cognito(Ref(:UserPoolId), Ref(:UserPoolClientId), Ref(:UserPoolDomainName))]
   
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
-            Actions actions
+            Actions FnIf(:EnableCognito, actions_with_cognito, actions)
             Conditions listener_conditions
             ListenerArn Ref(targetgroup['listener_resource'])
             Priority rule['priority']

--- a/ecs-service.cfndsl.rb
+++ b/ecs-service.cfndsl.rb
@@ -401,10 +401,19 @@ CloudFormation do
             rule_name = "TargetRule#{index}"
           end
           rule_names << rule_name
+
+          actions = []
+          actions << { Type: "forward", Order: 5000, TargetGroupArn: Ref(targetgroup['resource_name']) }
+
+          if targetgroup.has_key?('cognito')
+            if targetgroup['cognito'] == true
+              actions << cognito(self)
+            end
+          end
   
           ElasticLoadBalancingV2_ListenerRule(rule_name) do
             Actions [{ Type: "forward", TargetGroupArn: Ref(targetgroup['resource_name']) }]
-            Conditions listener_conditions
+            Conditions actions
             ListenerArn Ref(targetgroup['listener_resource'])
             Priority rule['priority']
           end

--- a/spec/ephemeral_storage_spec.rb
+++ b/spec/ephemeral_storage_spec.rb
@@ -12,7 +12,23 @@ describe 'compiled component ecs-service' do
   
   context "Resource" do
 
+    
+    context "LogGroup" do
+      let(:resource) { template["Resources"]["LogGroup"] }
 
+      it "is of type AWS::Logs::LogGroup" do
+          expect(resource["Type"]).to eq("AWS::Logs::LogGroup")
+      end
+      
+      it "to have property LogGroupName" do
+          expect(resource["Properties"]["LogGroupName"]).to eq({"Ref"=>"AWS::StackName"})
+      end
+      
+      it "to have property RetentionInDays" do
+          expect(resource["Properties"]["RetentionInDays"]).to eq("7")
+      end
+      
+    end
     
     context "Task" do
       let(:resource) { template["Resources"]["Task"] }
@@ -24,17 +40,66 @@ describe 'compiled component ecs-service' do
       it "to have property ContainerDefinitions" do
           expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"nginx", "Image"=>{"Fn::Join"=>["", ["nginx/", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"nginx"}}}])
       end
-
-      it "to have property ContainerDefinitions" do
-        expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"nginx", "Image"=>{"Fn::Join"=>["", ["nginx/", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"nginx"}}}])
-    end
       
       it "to have property EphemeralStorage" do
           expect(resource["Properties"]["EphemeralStorage"]).to eq({"SizeInGiB"=>50})
       end
       
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"ecs-service"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
     end
     
+    context "Role" do
+      let(:resource) { template["Resources"]["Role"] }
+
+      it "is of type AWS::IAM::Role" do
+          expect(resource["Type"]).to eq("AWS::IAM::Role")
+      end
+      
+      it "to have property AssumeRolePolicyDocument" do
+          expect(resource["Properties"]["AssumeRolePolicyDocument"]).to eq({"Version"=>"2012-10-17", "Statement"=>[{"Effect"=>"Allow", "Principal"=>{"Service"=>"ecs.amazonaws.com"}, "Action"=>"sts:AssumeRole"}]})
+      end
+      
+      it "to have property Path" do
+          expect(resource["Properties"]["Path"]).to eq("/")
+      end
+      
+      it "to have property ManagedPolicyArns" do
+          expect(resource["Properties"]["ManagedPolicyArns"]).to eq(["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"])
+      end
+      
+    end
+    
+    context "Service" do
+      let(:resource) { template["Resources"]["Service"] }
+
+      it "is of type AWS::ECS::Service" do
+          expect(resource["Type"]).to eq("AWS::ECS::Service")
+      end
+      
+      it "to have property Cluster" do
+          expect(resource["Properties"]["Cluster"]).to eq({"Ref"=>"EcsCluster"})
+      end
+      
+      it "to have property DesiredCount" do
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+      end
+      
+      it "to have property DeploymentConfiguration" do
+          expect(resource["Properties"]["DeploymentConfiguration"]).to eq({"MinimumHealthyPercent"=>{"Ref"=>"MinimumHealthyPercent"}, "MaximumPercent"=>{"Ref"=>"MaximumPercent"}})
+      end
+      
+      it "to have property TaskDefinition" do
+          expect(resource["Properties"]["TaskDefinition"]).to eq({"Ref"=>"Task"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>"ecs-service"}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+    end
     
   end
 

--- a/spec/extra_hosts_spec.rb
+++ b/spec/extra_hosts_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/fargate_spec.rb
+++ b/spec/fargate_spec.rb
@@ -83,7 +83,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/linux_parameters_spec.rb
+++ b/spec/linux_parameters_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/multiple_links_spec.rb
+++ b/spec/multiple_links_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/multiple_scaling_policies_spec.rb
+++ b/spec/multiple_scaling_policies_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/multiple_target_groups_parameter_spec.rb
+++ b/spec/multiple_target_groups_parameter_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/multiple_target_groups_spec.rb
+++ b/spec/multiple_target_groups_spec.rb
@@ -88,7 +88,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property Actions" do
-          expect(resource["Properties"]["Actions"]).to eq([{"Type"=>"forward", "TargetGroupArn"=>{"Ref"=>"nginxhttpTargetGroup"}}])
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"nginxhttpTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"nginxhttpTargetGroup"}}]]})
       end
       
       it "to have property Conditions" do
@@ -146,7 +146,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property Actions" do
-          expect(resource["Properties"]["Actions"]).to eq([{"Type"=>"forward", "TargetGroupArn"=>{"Ref"=>"nginxhttpsTargetGroup"}}])
+          expect(resource["Properties"]["Actions"]).to eq({"Fn::If"=>["EnableCognito", [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"nginxhttpsTargetGroup"}}, {"Type"=>"authenticate-cognito", "Order"=>1, "AuthenticateCognitoConfig"=>{"UserPoolArn"=>{"Ref"=>"UserPoolId"}, "UserPoolClientId"=>{"Ref"=>"UserPoolClientId"}, "UserPoolDomain"=>{"Ref"=>"UserPoolDomainName"}}}], [{"Type"=>"forward", "Order"=>5000, "TargetGroupArn"=>{"Ref"=>"nginxhttpsTargetGroup"}}]]})
       end
       
       it "to have property Conditions" do
@@ -196,7 +196,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/nginx_service_spec.rb
+++ b/spec/nginx_service_spec.rb
@@ -84,7 +84,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/scheduling_strategy_replica_spec.rb
+++ b/spec/scheduling_strategy_replica_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/secrets_spec.rb
+++ b/spec/secrets_spec.rb
@@ -71,7 +71,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property Policies" do
-          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"ssm-secrets", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"ssmsecrets", "Action"=>"ssm:GetParameters", "Resource"=>[{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/key"}, {"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/secret"}], "Effect"=>"Allow"}]}}, {"PolicyName"=>"secretsmanager", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"secretsmanager", "Action"=>"secretsmanager:GetSecretValue", "Resource"=>[{"Fn::Sub"=>"arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/dont/use/accesskeys-*"}, {"Ref"=>"EnvironmentName"}], "Effect"=>"Allow"}]}}])
+          expect(resource["Properties"]["Policies"]).to eq([{"PolicyName"=>"ssm-secrets", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"ssmsecrets", "Action"=>"ssm:GetParameters", "Resource"=>[{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/key*"}, {"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/secret*"}], "Effect"=>"Allow"}]}}, {"PolicyName"=>"secretsmanager", "PolicyDocument"=>{"Statement"=>[{"Sid"=>"secretsmanager", "Action"=>"secretsmanager:GetSecretValue", "Resource"=>[{"Fn::Sub"=>"arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/dont/use/accesskeys*"}, {"Fn::Sub"=>"arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:{\"Ref\"=>\"EnvironmentName\"}*"}], "Effect"=>"Allow"}]}}])
       end
       
     end
@@ -84,7 +84,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property ContainerDefinitions" do
-          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"nginx", "Image"=>{"Fn::Join"=>["", ["nginx/", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"nginx"}}, "Secrets"=>[{"Name"=>"API_KEY", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/key"}}, {"Name"=>"API_SECRET", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/secret"}}, {"Name"=>"ACCESSKEY", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/dont/use/accesskeys"}}, {"Name"=>"SECRETKEY", "ValueFrom"=>{"Ref"=>"EnvironmentName"}}]}])
+          expect(resource["Properties"]["ContainerDefinitions"]).to eq([{"Name"=>"nginx", "Image"=>{"Fn::Join"=>["", ["nginx/", "nginx", ":", "latest"]]}, "LogConfiguration"=>{"LogDriver"=>"awslogs", "Options"=>{"awslogs-group"=>{"Ref"=>"LogGroup"}, "awslogs-region"=>{"Ref"=>"AWS::Region"}, "awslogs-stream-prefix"=>"nginx"}}, "Secrets"=>[{"Name"=>"API_KEY", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/key"}}, {"Name"=>"API_SECRET", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/nginx/${EnvironmentName}/api/secret"}}, {"Name"=>"ACCESSKEY", "ValueFrom"=>"/dont/use/accesskeys"}, {"Name"=>"SECRETKEY", "ValueFrom"=>{"Fn::Sub"=>"arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:{\"Ref\"=>\"EnvironmentName\"}"}}]}])
       end
       
       it "to have property TaskRoleArn" do
@@ -134,7 +134,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/security_group_spec.rb
+++ b/spec/security_group_spec.rb
@@ -104,7 +104,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/task_placement_constraint_spec.rb
+++ b/spec/task_placement_constraint_spec.rb
@@ -84,7 +84,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -80,7 +80,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do

--- a/spec/volumes_spec.rb
+++ b/spec/volumes_spec.rb
@@ -109,7 +109,7 @@ describe 'compiled component ecs-service' do
       end
       
       it "to have property DesiredCount" do
-          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If" => ["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
+          expect(resource["Properties"]["DesiredCount"]).to eq({"Fn::If"=>["NoDesiredCount", {"Ref"=>"AWS::NoValue"}, {"Ref"=>"DesiredCount"}]})
       end
       
       it "to have property DeploymentConfiguration" do


### PR DESCRIPTION
Added cognito support for ecs-service component.

Cognito is enabled by provisioning the `cognitio` component and adding the parameter `cognito:true` to a target group. The a new listener rule for cognito will then be created alongside the other defined rules. 

Note - Atleast one other rule must be defined

Target Group Example 
```
targetgroup:
-
  name: default
  protocol: http
  cognito: true
  container: nginx
  port: 80
  rules:
    -  
      priority: 10
      path: /v1
